### PR TITLE
Translate navigation bar on all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,24 @@
 Add Simplified Chinese weapons and perks display for light.gg.
 
 ## 使用 / Usage
+### 用户脚本安装
 1. 在你的浏览器上安装[Tampermonkey](https://www.tampermonkey.net/)扩展
 2. 进入[脚本发布页](https://greasyfork.org/zh-CN/scripts/427267-simplified-chinese-for-light-gg?locale_override=1), 点击"安装此脚本"，在弹出页面中确认安装
 3. 进入任意light.gg武器页面，比如[这个](https://www.light.gg/db/items/304659313/ignition-code/)
 4. 若为第一次安装，此时武器页面已为简体中文，可以点击右上角的"简"/"原"按钮进行切换
+
+### 一次性使用
+1. 进入任意light.gg武器页面，比如[这个](https://www.light.gg/db/items/304659313/ignition-code/)
+2. 按下 `Ctrl + Shift + J` 快捷键打开浏览器的控制台
+3. 在控制台中粘贴以下代码，并回车执行
+```javascript
+(function(){
+    var d = document;
+    var s = d.createElement('script');
+    s.setAttribute('src', 'https://cdn.jsdelivr.net/gh/HZDeluxe/Simplified-Chinese-for-light-gg@main/sc4lightgg.user.js');
+    d.head.appendChild(s);
+})();
+```
 
 ## 其他工具 / Other Tools
 [DIM 链接到 light.gg / light.gg linking for DIM](https://greasyfork.org/scripts/427285-light-gg-linking-for-dim)

--- a/sc4lightgg.user.js
+++ b/sc4lightgg.user.js
@@ -20,23 +20,20 @@
         data: {
             item: { ready: false }
         },
+        common: {
+            navbar: { 
+                selector: '#navbar-collapse', 
+                ontranslate: translNavbar 
+            }
+        },
         pages: {
             index: {
                 path: /^\/$/i,
-                elms: {
-                    navbar: { 
-                        selector: '#navbar-collapse', 
-                        ontranslate: translNavbar 
-                    }
-                }
+                elms: {}
             },
             item: {
                 path: /\/items\/(\d+)\//i,
                 elms: {
-                    navbar: { 
-                        selector: '#navbar-collapse', 
-                        ontranslate: translNavbar 
-                    },
                     itemHeader: { 
                         selector: '#main-column > .item-header', 
                         ontranslate:  translItemHeader 
@@ -123,13 +120,18 @@
         },
         utils: {
             getCurrentPage: function() {
-                for (var prop in lgg.pages) {
-                    var path = lgg.pages[prop].path;
+                var p = { elms: {} };
+                for (var propPage in lgg.pages) {
+                    var path = lgg.pages[propPage].path;
                     if(path.test(location.pathname)) {
-                        return lgg.pages[prop];
+                        p = lgg.pages[propPage];
+                        break;
                     }
                 }
-                return null;
+                for (var propCommon in lgg.common) {
+                    p.elms[propCommon] = lgg.common[propCommon];
+                }
+                return p;
             },
             getItemId: function() {
                 var matches = location.pathname.match(/\/items\/(\d+)\//i);


### PR DESCRIPTION
Put navbar in a common object instead of every page object, and append navbar back to every page object before translation.
This PR fixes #5.